### PR TITLE
Alteração do tamanho da logo em breakpoint

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,8 @@ h1.display-4 {
 
     .logo-default {
         content: url(../image/logoMactecMarcaDaguaX.png);
+        width: 170px;
+        height: auto;
     }
 
 }
@@ -451,9 +453,9 @@ h1.display-4 {
         left: -6px;
     }
 
-    .logo-img {
+    /*.logo-img {
         max-width: 100px;
-    }
+    }*/
 }
 
 


### PR DESCRIPTION
Foi alterada a configuração do tamanho da imagem da logo no breakpoint na linha 418 do arquivo style.css, e comentada a limitação do tamanho max-width na linha 456, em devices menores